### PR TITLE
Trying to implement gzip decompression of request body

### DIFF
--- a/stream_parser.h
+++ b/stream_parser.h
@@ -39,7 +39,8 @@ private:
     std::string body_100_continue;
 
     std::string temp_header_field;
-    bool gzip_flag;
+    bool gzip_response_flag;
+    bool gzip_request_flag;
     int dump_flag;
 
     uint32_t fin_nxtseq[HTTP_BOTH];


### PR DESCRIPTION
fixes #10 

I am not a C++ programmer IDK if this will leak memory or explode or not, but it works in my tests, request body is shown when before it was just `[binary request body] (size:2968)`